### PR TITLE
pre-building to list only successful builds

### DIFF
--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -6,7 +6,7 @@ from sphinx import application
 from sphinx.config import Config as SphinxConfig
 from sphinx.cmd.build import build_main
 from sphinx.errors import SphinxError
-from sphinx_versioned.versions import GitVersions
+from sphinx_versioned.versions import GitVersions, BuiltVersions
 
 from loguru import logger as log
 
@@ -39,17 +39,19 @@ class VersionedDocs:
         self.config = config
         self._parse_config(config)
 
+        self._versions_to_pre_build = []
         self._versions_to_build = []
         self._failed_build = []
         self._quite = "-Q" if self.quite else None
 
         self._handle_paths()
+        self._get_versions_to_pre_build()
+        self._pre_build_versions()
 
         # Adds our extension to the sphinx-config
         application.Config = ConfigInject
 
-        self._get_versions_to_build()
-        self._build_all_version()
+        self._build_versions()
         pass
 
     def _parse_config(self, config):
@@ -57,26 +59,20 @@ class VersionedDocs:
             setattr(self, varname, value)
         return True
 
-    def _log_all_version_to_build(self) -> bool:
-        for tag in self._versions_to_build:
-            log.info(f"found version: {tag.name}")
+    def _log_versions(
+        self,
+        versions,
+        msg="found version",
+    ) -> bool:
+        for tag in versions:
+            log.info(f"{msg}: {tag.name}")
         return True
 
-    def _get_versions_to_build(self) -> bool:
-        self._versions_to_build.extend(self.versions.repo.tags)
-        self._versions_to_build.extend(self.versions.repo.branches)
-        return self._log_all_version_to_build()
-
     def _handle_paths(self):
-        if self.chdir:
-            os.chdir(self.chdir)
-        else:
-            self.chdir = os.getcwd()
+        self.chdir = self.chdir if self.chdir else os.getcwd()
         log.debug(f"Working directory {self.chdir}")
 
         self.versions = GitVersions(self.git_root, self.output_dir)
-        EventHandlers.VERSIONS = self.versions
-
         self.local_conf = pathlib.Path(self.local_conf)
         if self.local_conf.name != "conf.py":
             self.local_conf = self.local_conf / "conf.py"
@@ -84,9 +80,46 @@ class VersionedDocs:
             log.error(f"conf.py does not exist at {self.local_conf}")
             raise FileNotFoundError(f"conf.py not found at {self.local_conf.parent}")
         log.success(f"located conf.py")
-        return True
+        return
 
-    def _checkout_and_build(self, tag):
+    def _get_versions_to_pre_build(self) -> bool:
+        self._versions_to_pre_build.extend(self.versions.repo.tags)
+        self._versions_to_pre_build.extend(self.versions.repo.branches)
+        log.info("Pre-building...")
+        return self._log_versions(self._versions_to_pre_build)
+
+    def _prebuild(self, tag):
+        # Checkout tag/branch
+        self.versions.checkout(tag)
+        with TempDir() as temp_dir:
+            log.debug(f"Checking out the latest tag in temporary directory: {temp_dir}")
+            source = str(self.local_conf.parent)
+            target = temp_dir
+            argv = (source, target)
+            if self._quite:
+                argv += (self._quite,)
+            result = build_main(argv)
+            if result != 0:
+                raise SphinxError
+
+            log.success(f"pre-build succeded for {tag} :)")
+
+    def _pre_build_versions(self):
+        # get active branch
+        self._active_branch = self.versions.active_branch
+
+        for tag in self._versions_to_pre_build:
+            log.info(f"pre-building: {tag}")
+            try:
+                self._prebuild(tag)
+                self._versions_to_build.append(tag)
+            except SphinxError:
+                log.error(f"Pre-build failed for {tag}")
+            finally:
+                # restore to active branch
+                self.versions.checkout(self._active_branch.name)
+
+    def _build(self, tag):
         # Checkout tag/branch
         self.versions.checkout(tag)
         EventHandlers.CURRENT_VERSION = tag
@@ -100,33 +133,33 @@ class VersionedDocs:
                 argv += (self._quite,)
             result = build_main(argv)
             if result != 0:
-                # Register failed builds
-                self._failed_build.append(tag)
                 raise SphinxError
 
             output_with_tag = pathlib.Path(self.output_dir) / tag
             if not output_with_tag.exists():
                 output_with_tag.mkdir(parents=True, exist_ok=True)
             shutil.copytree(temp_dir, output_with_tag, False, None, dirs_exist_ok=True)
-            log.success("build succeded ;)")
+            log.success(f"build succeded for {tag} ;)")
 
-    def _build_all_version(self):
+    def _build_versions(self):
         # get active branch
         self._active_branch = self.versions.active_branch
 
         self._built_version = []
-        # for tag in self._versions_to_build:
-        tag = self._versions_to_build[-1].name
-        log.info(f"Building: {tag}")
-        try:
-            self._checkout_and_build(tag)
-        except SphinxError:
-            self._built_version.append(tag)
-            log.error(f"build failed for {tag}")
-            exit(-1)
-        finally:
-            # restore to active branch
-            self.versions.checkout(self._active_branch.name)
+        self._log_versions(self._versions_to_build, msg="building versions")
+        EventHandlers.VERSIONS = BuiltVersions(self._versions_to_build, self.versions.build_directory)
+
+        for tag in self._versions_to_build:
+            log.info(f"Building: {tag}")
+            try:
+                self._build(tag.name)
+                self._built_version.append(tag)
+            except SphinxError:
+                log.error(f"build failed for {tag}")
+                exit(-1)
+            finally:
+                # restore to active branch
+                self.versions.checkout(self._active_branch)
 
 
 @app.command("build")

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -208,7 +208,8 @@ def main(
     ),
     quite: bool = typer.Option(True, help="No output from `sphinx`"),
 ) -> None:
-    select_branches = re.split(",|\ ", select_branches)
+    if select_branches:
+        select_branches = re.split(",|\ ", select_branches)
     return VersionedDocs(locals())
 
 

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -120,6 +120,11 @@ class VersionedDocs:
             log.success(f"pre-build succeded for {tag} :)")
 
     def _pre_build_versions(self):
+        if not self.pre_build:
+            log.info("No pre-builing...")
+            self._versions_to_build = self._versions_to_pre_build
+            return
+
         log.info("Pre-building...")
 
         # get active branch

--- a/sphinx_versioned/versions.py
+++ b/sphinx_versioned/versions.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from git import Repo
+import git
 from loguru import logger as log
 
 
@@ -17,9 +17,9 @@ class GitVersions(object):
         if not self.build_directory.exists():
             self.build_directory.mkdir(parents=True, exist_ok=True)
 
-        self.repo = Repo(git_root)
+        self.repo = git.Repo(git_root)
         if self.repo.bare:
-            self.repo = Repo(os.getcwd())
+            self.repo = git.Repo(os.getcwd())
             if self.repo.bare:
                 log.error("Bare repo")
                 exit(-1)
@@ -57,3 +57,41 @@ class GitVersions(object):
         if self._active_branch:
             return self._active_branch
         return self.repo.active_branch
+
+
+class BuiltVersions:
+    def __init__(self, versions, build_directory) -> None:
+        self._versions = versions
+        self.build_directory = pathlib.Path(build_directory)
+
+        if not self.build_directory.exists():
+            self.build_directory.mkdir(parents=True, exist_ok=True)
+
+        self._parse()
+
+    def _parse(self) -> bool:
+        self._raw_tags = []
+        self._raw_branches = []
+
+        for tag in self._versions:
+            if isinstance(tag, git.TagReference):
+                self._raw_tags.append(tag)
+            else:
+                self._raw_branches.append(tag)
+
+        self._branches = {x.name: self.build_directory / x.name for x in self._raw_branches}
+        self._tags = {x.name: self.build_directory / x.name for x in self._raw_tags}
+        return True
+
+    @property
+    def branches(self) -> dict:
+        return {
+            x: "../" + str(y.relative_to(self.build_directory) / "index.html")
+            for x, y in self._branches.items()
+        }
+
+    @property
+    def tags(self) -> dict:
+        return {
+            x: "../" + str(y.relative_to(self.build_directory) / "index.html") for x, y in self._tags.items()
+        }


### PR DESCRIPTION
Prebuilding all tags and branches will **double** the build time; however, it can be avoided by:
- specifically selecting the tag/branch names via ``--branches`` argument, note that it takes a `str` argument of the form ``"main, master"``
- by providing the ``--no-pre-build`` arg

Fixes #9
Fixes #8 
