### PR TITLE
Patches intersphinx mapping for now

### DIFF
--- a/docs/changes/25.bugfix.rst
+++ b/docs/changes/25.bugfix.rst
@@ -1,0 +1,1 @@
+Hotfix for #17. It solves by resetting the intersphinx mapping var for the next execution. Forces ``--no-prebuild``.

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -203,6 +203,9 @@ def main(
         "--root-ref",
         help="The branch/tag at the root of DESTINATION. Will also be in subdir.",
     ),
+    reset_intersphinx_mapping: bool = typer.Option(
+        False, "--reset-intersphinx", "-rI", help="Reset intersphinx mapping; acts as a patch for issue #17"
+    ),
     prebuild: bool = typer.Option(True, help="Disables the pre-builds; halves the runtime"),
     select_branches: str = typer.Option(
         None, "-b", "--branches", help="Build docs for specific branches and tags"
@@ -217,6 +220,10 @@ def main(
 ) -> None:
     if select_branches:
         select_branches = re.split(",|\ ", select_branches)
+    EventHandlers.RESET_INTERSPHINX_MAPPING = reset_intersphinx_mapping
+    if reset_intersphinx_mapping:
+        log.error("Forcing --no-prebuild")
+        prebuild = False
     return VersionedDocs(locals())
 
 

--- a/sphinx_versioned/sphinx_.py
+++ b/sphinx_versioned/sphinx_.py
@@ -36,6 +36,7 @@ class EventHandlers(object):
     SHOW_BANNER = False
     VERSIONS = None
     ASSETS_TO_COPY = []
+    RESET_INTERSPHINX_MAPPING = False
 
     @staticmethod
     def builder_inited(app):
@@ -73,7 +74,13 @@ class EventHandlers(object):
             EventHandlers.ASSETS_TO_COPY.append("fontawesome-webfont.woff")
 
     @classmethod
-    def copy_custom_files(cls, app, exc):
+    def builder_finished_tasks(cls, app, exc):
+        if cls.RESET_INTERSPHINX_MAPPING:
+            log.debug("Reset intersphinx mappings")
+            for key, value in app.config.intersphinx_mapping.values():
+                app.config.intersphinx_mapping[key] = value
+            print(app.config.intersphinx_mapping)
+
         if app.builder.format == "html" and not exc:
             staticdir = os.path.join(app.builder.outdir, "_static")
             for asset in cls.ASSETS_TO_COPY:
@@ -140,5 +147,5 @@ def setup(app):
     app.connect("builder-inited", EventHandlers.builder_inited)
     app.connect("env-updated", EventHandlers.env_updated)
     app.connect("html-page-context", EventHandlers.html_page_context)
-    app.connect("build-finished", EventHandlers.copy_custom_files)
+    app.connect("build-finished", EventHandlers.builder_finished_tasks)
     return dict(version=__version__)


### PR DESCRIPTION
Fixes #17 for now.

It solves by resetting the intersphinx mapping var for the next execution. To be used in conjunction with `--no-prebuild`

Hot fix for the error
```
Handler <function load_mappings at 0x7fd7b20c0790> for event 'builder-inited' threw an exception (exception: 'tuple' object has no attribute 'decode')
```