### PR TITLE
Removed `_rtd_versions.js` in `sphinx_rtd_theme`

### DIFF
--- a/docs/changes/27.bugfix.rst
+++ b/docs/changes/27.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed version menu flyout script in `sphinx_rtd_theme`. Not entirely sure why but somehow `sphinx_rtd_theme` doesn't require the flyout script anymore.

--- a/sphinx_versioned/sphinx_.py
+++ b/sphinx_versioned/sphinx_.py
@@ -65,10 +65,9 @@ class EventHandlers(object):
 
         log.info(f"Theme: {app.config.html_theme}")
         # Insert flyout script
-        if app.config.html_theme == "sphinx_rtd_theme" or app.config.html_theme == "bootstrap-astropy":
+        if app.config.html_theme == "bootstrap-astropy":
             app.add_js_file("_rtd_versions.js")
             EventHandlers.ASSETS_TO_COPY.append("_rtd_versions.js")
-        if app.config.html_theme == "bootstrap-astropy":
             app.add_css_file("badge_only.css")
             EventHandlers.ASSETS_TO_COPY.append("badge_only.css")
             EventHandlers.ASSETS_TO_COPY.append("fontawesome-webfont.woff")


### PR DESCRIPTION
somehow sphinx_rtd_theme doesn't require the flyout script anymore