### PR TITLE
Build detached commits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,11 @@ How to use
     │ --sphinx-compatibility  -Sc                          Adds compatibility for older sphinx versions by monkey patching certain functions.                   │
     │ --prebuild                    --no-prebuild          Disables the pre-builds; halves the runtime [default: prebuild]                                      │
     │ --branches              -b                     TEXT  Build docs for specific branches and tags [default: None]                                            │
-    │ --main-branch           -m                     TEXT  Main branch to which the top-level `index.html` redirects to. [default: main]                        │
+    │ --main-branch           -m                     TEXT  Main branch to which the top-level `index.html` redirects to. Defaults to `main`. [default: None]    │
     │ --quite                       --no-quite             No output from `sphinx` [default: quite]                                                             │
     │ --verbose               -v                           Passed directly to sphinx. Specify more than once for more logging in sphinx.                        │
     │ --log                   -log                   TEXT  Provide logging level. Example --log debug, default=info [default: info]                             │
+    │ --force                                              Force branch selection. Use this option to build detached head/commits. [Default: False]             │
     │ --help                                               Show this message and exit.                                                                          │
     ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/docs/changes/45.feature.rst
+++ b/docs/changes/45.feature.rst
@@ -1,2 +1,4 @@
 Adds the capability to build detached heads if either the head is already detached or that particular commit is
-specified via `--branches` arg, both of these will work if and only if `--force` is supplied too. 
+specified via `--branches` arg, provided that `--force` is supplied. Additionally, if the main-branch is not
+specified via `--main-branch` then the currently checkout out branch/tag will be considered as the main branch
+for generating the top-level `index.html`.

--- a/docs/changes/45.feature.rst
+++ b/docs/changes/45.feature.rst
@@ -1,0 +1,2 @@
+Adds the capability to build detached heads if either the head is already detached or that particular commit is
+specified via `--branches` arg, both of these will work if and only if `--force` is supplied too. 

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -112,7 +112,7 @@ class VersionedDocs:
         _all_versions.extend(self.versions.repo.tags)
         _all_versions.extend(self.versions.repo.branches)
 
-        # check if the current git status is detached, if yes, append if `--force` is supplied
+        # check if `--force` is supplied, if yes, and if the current git status is detached, append:
         if self.force_branches:
             if self.versions.repo.head.is_detached:
                 log.warning(f"git detached {self.versions.repo.head.is_detached}")

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -8,7 +8,7 @@ from sphinx import application
 from sphinx.errors import SphinxError
 from sphinx.cmd.build import build_main
 from sphinx.config import Config as SphinxConfig
-from sphinx_versioned.versions import GitVersions, BuiltVersions
+from sphinx_versioned.versions import GitVersions, BuiltVersions, PseudoBranch
 
 from loguru import logger as log
 
@@ -89,7 +89,7 @@ class VersionedDocs:
         `bool`
         """
         for tag in versions:
-            log.info(f"{msg}: {tag.name}")
+            log.debug(f"{msg}: {tag.name}")
         return True
 
     def _handle_paths(self) -> None:
@@ -111,23 +111,41 @@ class VersionedDocs:
         _all_versions = []
         _all_versions.extend(self.versions.repo.tags)
         _all_versions.extend(self.versions.repo.branches)
+
+        # check if the current git status is detached, if yes, append if `--force` is supplied
+        if self.force_branches:
+            if self.versions.repo.head.is_detached:
+                log.warning(f"git detached {self.versions.repo.head.is_detached}")
+                _all_versions.append(PseudoBranch(self.versions.repo.head.object.hexsha))
+
         self._log_versions(_all_versions)
         return _all_versions
 
     def _select_specific_branches(self) -> list:
-        _all_versions = self._get_all_versions()
+        log.debug(f"Instructions to select: `{self.select_branches}`")
+
+        _all_versions = {x.name: x for x in self._get_all_versions()}
         _select_specific_branches = []
 
-        for tag in _all_versions:
-            if tag.name in self.select_branches:
-                log.info(f"Selecting tag for further processing: {tag.name}")
-                _select_specific_branches.append(tag)
+        for tag in self.select_branches:
+            if tag in _all_versions.keys():
+                log.info(f"Selecting tag for further processing: {tag}")
+                _select_specific_branches.append(_all_versions[tag])
+            elif self.force_branches is True:
+                log.warning(f"Forcing build for branch `{tag}`, be careful, it may or may not exist!")
+                _select_specific_branches.append(PseudoBranch(tag))
+            else:
+                log.critical(f"Branch not found: `{tag}`, use `--force` to force the build")
+
         return _select_specific_branches
 
     def _generate_top_level_index(self) -> None:
         """Generate a top-level ``index.html`` with redirect to the main-branch version."""
         if self.main_branch not in [x.name for x in self._built_version]:
-            log.critical(f"main branch {self.main_branch} not found!!")
+            log.critical(
+                f"main branch `{self.main_branch}` not found!! / not building `{self.main_branch}`; top-level `index.html` will not be generated!"
+            )
+            return
 
         with open(self.output_dir / "index.html", "w") as findex:
             findex.write(
@@ -140,7 +158,6 @@ class VersionedDocs:
                 </head>
             """
             )
-        log.debug(f"main branch '{self.main_branch}' found")
         return
 
     def _build(self, tag, _prebuild=False) -> bool:
@@ -162,7 +179,7 @@ class VersionedDocs:
         EventHandlers.CURRENT_VERSION = tag
 
         with TempDir() as temp_dir:
-            log.debug(f"Checking out the latest tag in temporary directory: {temp_dir}")
+            log.debug(f"Checking out the tag in temporary directory: {temp_dir}")
             source = str(self.local_conf.parent)
             target = temp_dir
             argv = (source, target)
@@ -189,7 +206,7 @@ class VersionedDocs:
             self._versions_to_build = self._versions_to_pre_build
             return
 
-        log.info("Pre-building...")
+        log.debug("Pre-building...")
 
         # get active branch
         self._active_branch = self.versions.active_branch
@@ -283,6 +300,11 @@ def main(
     ),
     loglevel: str = typer.Option(
         "info", "-log", "--log", help="Provide logging level. Example --log debug, default=info"
+    ),
+    force_branches: bool = typer.Option(
+        False,
+        "--force",
+        help="Force branch selection. Use this option to build detached head/commits. [Default: False]",
     ),
 ) -> None:
     if select_branches:

--- a/sphinx_versioned/_templates/versions.html
+++ b/sphinx_versioned/_templates/versions.html
@@ -98,25 +98,27 @@
 {% else %}
 <h3>{{ _('Versions') }}</h3>
 <ul>
-  {%- if versions.tags %}
-  <p>Tags</p>
-  <div class="dropdown-content">
-    {%- for name, url in versions.tags.items() %}
-    <div class="{{'rtd-current-item' if name==current_version }}">
-      <a href="{{ relpath }}{{ url }}">{{ name }}</a>
+  <div class="injected">
+    {%- if versions.tags %}
+    <p>Tags</p>
+    <div class="dropdown-content">
+      {%- for name, url in versions.tags.items() %}
+      <div class="{{'rtd-current-item' if name==current_version }}">
+        <a href="{{ relpath }}{{ url }}">{{ name }}</a>
+      </div>
+      {%- endfor %}
     </div>
-    {%- endfor %}
-  </div>
-  {%- endif %}
-  {%- if versions.branches %}
-  <p>Branches</p>
-  <div class="dropdown-content">
-    {%- for name, url in versions.branches.items() %}
-    <div class="{{'rtd-current-item' if name==current_version }}">
-      <a href="{{ relpath }}{{ url }}">{{ name }}</a>
+    {%- endif %}
+    {%- if versions.branches %}
+    <p>Branches</p>
+    <div class="dropdown-content">
+      {%- for name, url in versions.branches.items() %}
+      <div class="{{'rtd-current-item' if name==current_version }}">
+        <a href="{{ relpath }}{{ url }}">{{ name }}</a>
+      </div>
+      {%- endfor %}
     </div>
-    {%- endfor %}
+    {%- endif %}
   </div>
-  {%- endif %}
 </ul>
 {% endif %}

--- a/sphinx_versioned/versions.py
+++ b/sphinx_versioned/versions.py
@@ -1,5 +1,3 @@
-"""Collect and sort version strings."""
-
 import os
 import git
 import pathlib
@@ -7,6 +5,19 @@ from abc import ABC
 from loguru import logger as log
 
 os.environ["GIT_PYTHON_REFRESH"] = "quiet"
+
+
+class PseudoBranch:
+    """Class to generate a branchname for git detached situation"""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        return
+
+    def __repr__(self) -> str:
+        return self.name
+
+    pass
 
 
 class _BranchTag(ABC):
@@ -91,6 +102,11 @@ class GitVersions(_BranchTag):
         """Property to get active_branch."""
         if self._active_branch:
             return self._active_branch
+
+        if self.repo.head.is_detached:
+            log.warning(f"git head detached: {self.repo.head.is_detached}")
+            return PseudoBranch(self.repo.head.object.hexsha)
+
         return self.repo.active_branch
 
     pass

--- a/sphinx_versioned/versions.py
+++ b/sphinx_versioned/versions.py
@@ -95,6 +95,7 @@ class GitVersions(_BranchTag):
             Name of branch/tag.
         """
         self._active_branch = name
+        log.debug(f"git checkout branch/tag: `{name}`")
         return self.repo.git.checkout(name, *args, **kwargs)
 
     @property


### PR DESCRIPTION
This pr adds the capability to build git detached heads.

It will detect and build the detached head commit if `--force` arg is supplied and if:
- the head is already detached / detached head is already checked out
- the detached commit is specified via `--branches` arg
- if the main-branch is not specified via `--main-branch` then the currently checkout out branch/tag will be considered as the main branch for generating the top-level `index.html.

Fixes #44