### PR TITLE
gh-action to deploy versioned docs to gh-pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,5 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy to github-pages
 
 on:
   # Runs on pushes targeting the default branch

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/docs/changes/46.doc.rst
+++ b/docs/changes/46.doc.rst
@@ -1,0 +1,1 @@
+Added a sample github-action for showcasing the process to build and deploy versioned docs to github-pages/other-locations.

--- a/docs/changes/46.doc.rst
+++ b/docs/changes/46.doc.rst
@@ -1,1 +1,1 @@
-Added a sample github-action for showcasing the process to build and deploy versioned docs to github-pages/other-locations.
+Added a sample github-action to showcase the process of building and deploying versioned docs to github-pages/other-locations.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -51,3 +51,17 @@ After the build has succeded, your docs should be available in `docs/_build/<bra
 .. note::
 
     Use ``--no-quite`` option to get output from the sphinx builder, adjust verbosity using ``-v``
+
+---------------------------
+
+Deploy to github pages via github actions
+=========================================
+
+A sample github action to build and deploy versioned documentation to github-pages is given:
+
+.. literalinclude:: ../.github/workflows/static.yml
+    :language: yaml
+
+.. note::
+
+    Note the use of ``fetch-depth: 0`` with ``actions/checkout`` to ensure all branches are available to build during runtime.


### PR DESCRIPTION
Added a sample github-action to showcase the process of building and deploying versioned docs to github-pages/other-locations.
