### PR TITLE
Refactor: segregated building workflow `VersionedDocs` from `__main__.py` to `build.py`

### DIFF
--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -78,7 +78,7 @@ def main(
     EventHandlers.RESET_INTERSPHINX_MAPPING = reset_intersphinx_mapping
 
     if reset_intersphinx_mapping:
-        log.error("Forcing --no-prebuild")
+        log.warning("Forcing --no-prebuild")
         prebuild = False
 
     if sphinx_compatibility:

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -1,12 +1,12 @@
 import re
 import sys
 import typer
-from sphinx import application
 
 from loguru import logger as log
 
 from sphinx_versioned.build import VersionedDocs
 from sphinx_versioned.sphinx_ import EventHandlers
+from sphinx_versioned.lib import mp_sphinx_compatibility
 
 app = typer.Typer(add_completion=False)
 
@@ -82,12 +82,7 @@ def main(
         prebuild = False
 
     if sphinx_compatibility:
-        """
-        Monkeypatching `sphinx.application.Sphinx.add_stylesheet` -> `sphinx.application.Sphinx.add_stylesheet`
-        to add compatibility for versions using older sphinx
-        """
-        log.info("Monkeypatching older sphinx app.add_stylesheet -> app.add_css_file")
-        application.Sphinx.add_stylesheet = application.Sphinx.add_css_file
+        mp_sphinx_compatibility()
 
     logger_format = "| <level>{level: <8}</level> | - <level>{message}</level>"
 

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -1,261 +1,14 @@
 import re
-import os
 import sys
 import typer
-import shutil
-import pathlib
 from sphinx import application
-from sphinx.errors import SphinxError
-from sphinx.cmd.build import build_main
-from sphinx.config import Config as SphinxConfig
-from sphinx_versioned.versions import GitVersions, BuiltVersions, PseudoBranch
 
 from loguru import logger as log
 
-from sphinx_versioned.lib import TempDir
+from sphinx_versioned.build import VersionedDocs
 from sphinx_versioned.sphinx_ import EventHandlers
 
-logger_format = "| <level>{level: <8}</level> | - <level>{message}</level>"
-
 app = typer.Typer(add_completion=False)
-
-
-class ConfigInject(SphinxConfig):
-    """Inject this extension info `self.extensions`. Append after user's extensions."""
-
-    def __init__(self, *args):
-        super(ConfigInject, self).__init__(*args)
-        self.extensions.append("sphinx_versioned.sphinx_")
-
-
-class VersionedDocs:
-    def __init__(self, config) -> None:
-        """Handles main workflow.
-
-        Parameters
-        ----------
-        config : `dict`
-        """
-        self.config = config
-        self._parse_config(config)
-        self._handle_paths()
-
-        self._versions_to_pre_build = []
-        self._versions_to_build = []
-        self._failed_build = []
-
-        # selectively build branches / build all branches
-        self._versions_to_pre_build = (
-            self._select_specific_branches() if self.select_branches else self._get_all_versions()
-        )
-
-        # if `--force` is supplied with no `--main-branch`, make the `_active_branch` as the `main_branch`
-        if not self.main_branch:
-            if self.force_branches:
-                self.main_branch = self.versions.active_branch.name
-            else:
-                self.main_branch = "main"
-
-        self._pre_build()
-
-        # Adds our extension to the sphinx-config
-        application.Config = ConfigInject
-
-        self.build()
-
-        # Adds a top-level `index.html` in `output_dir` which redirects to `output_dir`/`main-branch`/index.html
-        self._generate_top_level_index()
-
-        print(f"\n\033[92m Successfully built {', '.join([x.name for x in self._built_version])} \033[0m")
-        return
-
-    def _parse_config(self, config) -> bool:
-        for varname, value in config.items():
-            setattr(self, varname, value)
-
-        self._additional_args = ()
-        self._additional_args += ("-Q",) if self.quite else ()
-        self._additional_args += ("-vv",) if self.verbose else ()
-        return True
-
-    def _log_versions(
-        self,
-        versions,
-        msg="found version",
-    ) -> bool:
-        """Logs versions to `stdout`
-
-        Parameters
-        ----------
-        versions : `~sphinx_versioned.versions.GitVersions`
-        mas : `str`
-
-        Return
-        ------
-        `bool`
-        """
-        for tag in versions:
-            log.debug(f"{msg}: {tag.name}")
-        return True
-
-    def _handle_paths(self) -> None:
-        """Method to handle cwd and path for local config."""
-        self.chdir = self.chdir if self.chdir else os.getcwd()
-        log.debug(f"Working directory {self.chdir}")
-
-        self.versions = GitVersions(self.git_root, self.output_dir)
-        self.output_dir = pathlib.Path(self.output_dir)
-        self.local_conf = pathlib.Path(self.local_conf)
-
-        if self.local_conf.name != "conf.py":
-            self.local_conf = self.local_conf / "conf.py"
-
-        if not self.local_conf.exists():
-            log.error(f"conf.py does not exist at {self.local_conf}")
-            raise FileNotFoundError(f"conf.py not found at {self.local_conf.parent}")
-
-        log.success(f"located conf.py")
-        return
-
-    def _get_all_versions(self) -> list:
-        _all_versions = []
-        _all_versions.extend(self.versions.repo.tags)
-        _all_versions.extend(self.versions.repo.branches)
-
-        # check if `--force` is supplied, if yes, and if the current git status is detached, append:
-        if self.force_branches:
-            if self.versions.repo.head.is_detached:
-                log.warning(f"git detached {self.versions.repo.head.is_detached}")
-                _all_versions.append(PseudoBranch(self.versions.repo.head.object.hexsha))
-
-        self._log_versions(_all_versions)
-        return _all_versions
-
-    def _select_specific_branches(self) -> list:
-        log.debug(f"Instructions to select: `{self.select_branches}`")
-
-        _all_versions = {x.name: x for x in self._get_all_versions()}
-        _select_specific_branches = []
-
-        for tag in self.select_branches:
-            if tag in _all_versions.keys():
-                log.info(f"Selecting tag for further processing: {tag}")
-                _select_specific_branches.append(_all_versions[tag])
-            elif self.force_branches:
-                log.warning(f"Forcing build for branch `{tag}`, be careful, it may or may not exist!")
-                _select_specific_branches.append(PseudoBranch(tag))
-            else:
-                log.critical(f"Branch not found: `{tag}`, use `--force` to force the build")
-
-        return _select_specific_branches
-
-    def _generate_top_level_index(self) -> None:
-        """Generate a top-level ``index.html`` with redirect to the main-branch version."""
-        if self.main_branch not in [x.name for x in self._built_version]:
-            log.critical(
-                f"main branch `{self.main_branch}` not found!! / not building `{self.main_branch}`; top-level `index.html` will not be generated!"
-            )
-            return
-
-        log.success(f"main branch: `{self.main_branch}`; generating top-level `index.html`")
-        with open(self.output_dir / "index.html", "w") as findex:
-            findex.write(
-                f"""
-                <!DOCTYPE html>
-                <html>
-                <head>
-                <meta http-equiv="refresh" content="0; url =
-                {self.main_branch}/index.html" />
-                </head>
-            """
-            )
-        return
-
-    def _build(self, tag, _prebuild=False) -> bool:
-        """Internal build method.
-
-        Parameters
-        ----------
-        tag : `~git.Branch` or `~git.Tag`
-            Branch/tag to build
-        _prebuild : `bool`
-            Variable to allow/skip pre-building verions
-
-        Returns
-        -------
-        `bool`
-        """
-        # Checkout tag/branch
-        self.versions.checkout(tag)
-        EventHandlers.CURRENT_VERSION = tag
-
-        with TempDir() as temp_dir:
-            log.debug(f"Checking out the tag in temporary directory: {temp_dir}")
-            source = str(self.local_conf.parent)
-            target = temp_dir
-            argv = (source, target)
-            argv += self._additional_args
-            result = build_main(argv)
-            if result != 0:
-                raise SphinxError
-
-            if _prebuild:
-                log.success(f"pre-build succeded for {tag} :)")
-                return True
-
-            output_with_tag = self.output_dir / tag
-            if not output_with_tag.exists():
-                output_with_tag.mkdir(parents=True, exist_ok=True)
-
-            shutil.copytree(temp_dir, output_with_tag, False, None, dirs_exist_ok=True)
-            log.success(f"build succeded for {tag} ;)")
-            return True
-
-    def _pre_build(self) -> None:
-        if not self.prebuild:
-            log.info("No pre-builing...")
-            self._versions_to_build = self._versions_to_pre_build
-            return
-
-        log.debug("Pre-building...")
-
-        # get active branch
-        self._active_branch = self.versions.active_branch
-
-        for tag in self._versions_to_pre_build:
-            log.info(f"pre-building: {tag}")
-            try:
-                self._build(tag, _prebuild=True)
-                self._versions_to_build.append(tag)
-            except SphinxError:
-                log.critical(f"Pre-build failed for {tag}")
-            finally:
-                # restore to active branch
-                self.versions.checkout(self._active_branch.name)
-
-        log.success(f"Prebuilding successful for {', '.join([x.name for x in self._versions_to_build])}")
-        return
-
-    def build(self) -> None:
-        """Build workflow."""
-        # get active branch
-        self._active_branch = self.versions.active_branch
-
-        self._built_version = []
-        EventHandlers.VERSIONS = BuiltVersions(self._versions_to_build, self.versions.build_directory)
-
-        for tag in self._versions_to_build:
-            log.info(f"Building: {tag}")
-            try:
-                self._build(tag.name)
-                self._built_version.append(tag)
-            except SphinxError:
-                log.error(f"build failed for {tag}")
-                exit(-1)
-            finally:
-                # restore to active branch
-                self.versions.checkout(self._active_branch)
-        return
 
 
 @app.command()
@@ -301,6 +54,7 @@ def main(
         "-m",
         "--main-branch",
         help="Main branch to which the top-level `index.html` redirects to. Defaults to `main`.",
+        show_default=False,
     ),
     quite: bool = typer.Option(True, help="No output from `sphinx`"),
     verbose: bool = typer.Option(
@@ -335,9 +89,27 @@ def main(
         log.info("Monkeypatching older sphinx app.add_stylesheet -> app.add_css_file")
         application.Sphinx.add_stylesheet = application.Sphinx.add_css_file
 
+    logger_format = "| <level>{level: <8}</level> | - <level>{message}</level>"
+
     log.remove()
     log.add(sys.stderr, format=logger_format, level=loglevel.upper())
-    return VersionedDocs(locals())
+    return VersionedDocs(
+        {
+            "chdir": chdir,
+            "output_dir": output_dir,
+            "git_root": git_root,
+            "local_conf": local_conf,
+            "reset_intersphinx_mapping": reset_intersphinx_mapping,
+            "sphinx_compatibility": sphinx_compatibility,
+            "prebuild": prebuild,
+            "select_branches": select_branches,
+            "main_branch": main_branch,
+            "quite": quite,
+            "verbose": verbose,
+            "loglevel": loglevel,
+            "force_branches": force_branches,
+        }
+    )
 
 
 if __name__ == "__main__":

--- a/sphinx_versioned/build.py
+++ b/sphinx_versioned/build.py
@@ -1,0 +1,226 @@
+import os
+import shutil
+import pathlib
+from sphinx import application
+from sphinx.errors import SphinxError
+from sphinx.cmd.build import build_main
+
+from loguru import logger as log
+
+from sphinx_versioned.sphinx_ import EventHandlers
+from sphinx_versioned.lib import TempDir, ConfigInject
+from sphinx_versioned.versions import GitVersions, BuiltVersions, PseudoBranch
+
+
+class VersionedDocs:
+    def __init__(self, config: dict) -> None:
+        """Handles main workflow.
+
+        Parameters
+        ----------
+        config : `dict`
+        """
+        self.config = config
+        self._parse_config(config)
+        self._handle_paths()
+
+        self._versions_to_pre_build = []
+        self._versions_to_build = []
+        self._failed_build = []
+
+        # selectively build branches / build all branches
+        self._versions_to_pre_build = (
+            self._select_specific_branches() if self.select_branches else self._get_all_versions()
+        )
+
+        # if `--force` is supplied with no `--main-branch`, make the `_active_branch` as the `main_branch`
+        if not self.main_branch:
+            if self.force_branches:
+                self.main_branch = self.versions.active_branch.name
+            else:
+                self.main_branch = "main"
+
+        self._pre_build()
+
+        # Adds our extension to the sphinx-config
+        application.Config = ConfigInject
+
+        self.build()
+
+        # Adds a top-level `index.html` in `output_dir` which redirects to `output_dir`/`main-branch`/index.html
+        self._generate_top_level_index()
+
+        print(f"\n\033[92m Successfully built {', '.join([x.name for x in self._built_version])} \033[0m")
+        return
+
+    def _parse_config(self, config: dict) -> bool:
+        for varname, value in config.items():
+            setattr(self, varname, value)
+
+        self._additional_args = ()
+        self._additional_args += ("-Q",) if self.quite else ()
+        self._additional_args += ("-vv",) if self.verbose else ()
+        return True
+
+    def _handle_paths(self) -> None:
+        """Method to handle cwd and path for local config."""
+        self.chdir = self.chdir if self.chdir else os.getcwd()
+        log.debug(f"Working directory {self.chdir}")
+
+        self.versions = GitVersions(self.git_root, self.output_dir)
+        self.output_dir = pathlib.Path(self.output_dir)
+        self.local_conf = pathlib.Path(self.local_conf)
+
+        if self.local_conf.name != "conf.py":
+            self.local_conf = self.local_conf / "conf.py"
+
+        if not self.local_conf.exists():
+            log.error(f"conf.py does not exist at {self.local_conf}")
+            raise FileNotFoundError(f"conf.py not found at {self.local_conf.parent}")
+
+        log.success(f"located conf.py")
+        return
+
+    def _get_all_versions(self) -> list:
+        _all_versions = []
+        _all_versions.extend(self.versions.repo.tags)
+        _all_versions.extend(self.versions.repo.branches)
+
+        # check if `--force` is supplied, if yes, and if the current git status is detached, append:
+        if self.force_branches:
+            if self.versions.repo.head.is_detached:
+                log.warning(f"git detached {self.versions.repo.head.is_detached}")
+                _all_versions.append(PseudoBranch(self.versions.repo.head.object.hexsha))
+
+        # self._log_versions(_all_versions)
+        log.debug(f"Found versions: {[x.name for x in _all_versions]}")
+        return _all_versions
+
+    def _select_specific_branches(self) -> list:
+        log.debug(f"Instructions to select: `{self.select_branches}`")
+
+        _all_versions = {x.name: x for x in self._get_all_versions()}
+        _select_specific_branches = []
+
+        for tag in self.select_branches:
+            if tag in _all_versions.keys():
+                log.info(f"Selecting tag for further processing: {tag}")
+                _select_specific_branches.append(_all_versions[tag])
+            elif self.force_branches:
+                log.warning(f"Forcing build for branch `{tag}`, be careful, it may or may not exist!")
+                _select_specific_branches.append(PseudoBranch(tag))
+            else:
+                log.critical(f"Branch not found: `{tag}`, use `--force` to force the build")
+
+        return _select_specific_branches
+
+    def _generate_top_level_index(self) -> None:
+        """Generate a top-level ``index.html`` with redirect to the main-branch version."""
+        if self.main_branch not in [x.name for x in self._built_version]:
+            log.critical(
+                f"main branch `{self.main_branch}` not found!! / not building `{self.main_branch}`; "
+                "top-level `index.html` will not be generated!"
+            )
+            return
+
+        log.success(f"main branch: `{self.main_branch}`; generating top-level `index.html`")
+        with open(self.output_dir / "index.html", "w") as findex:
+            findex.write(
+                f"""
+                <!DOCTYPE html>
+                <html>
+                <head>
+                <meta http-equiv="refresh" content="0; url =
+                {self.main_branch}/index.html" />
+                </head>
+            """
+            )
+        return
+
+    def _build(self, tag, _prebuild: bool = False) -> bool:
+        """Internal build method.
+
+        Parameters
+        ----------
+        tag : `~git.Branch` or `~git.Tag`
+            Branch/tag to build
+        _prebuild : `bool`
+            Variable to allow/skip pre-building verions
+
+        Returns
+        -------
+        `bool`
+        """
+        # Checkout tag/branch
+        self.versions.checkout(tag)
+        EventHandlers.CURRENT_VERSION = tag
+
+        with TempDir() as temp_dir:
+            log.debug(f"Checking out the tag in temporary directory: {temp_dir}")
+            source = str(self.local_conf.parent)
+            target = temp_dir
+            argv = (source, target)
+            argv += self._additional_args
+            result = build_main(argv)
+            if result != 0:
+                raise SphinxError
+
+            if _prebuild:
+                log.success(f"pre-build succeded for {tag} :)")
+                return True
+
+            output_with_tag = self.output_dir / tag
+            if not output_with_tag.exists():
+                output_with_tag.mkdir(parents=True, exist_ok=True)
+
+            shutil.copytree(temp_dir, output_with_tag, False, None, dirs_exist_ok=True)
+            log.success(f"build succeded for {tag} ;)")
+            return True
+
+    def _pre_build(self) -> None:
+        if not self.prebuild:
+            log.info("No pre-builing...")
+            self._versions_to_build = self._versions_to_pre_build
+            return
+
+        log.debug("Pre-building...")
+
+        # get active branch
+        self._active_branch = self.versions.active_branch
+
+        for tag in self._versions_to_pre_build:
+            log.info(f"pre-building: {tag}")
+            try:
+                self._build(tag, _prebuild=True)
+                self._versions_to_build.append(tag)
+            except SphinxError:
+                log.critical(f"Pre-build failed for {tag}")
+            finally:
+                # restore to active branch
+                self.versions.checkout(self._active_branch.name)
+
+        log.success(f"Prebuilding successful for {', '.join([x.name for x in self._versions_to_build])}")
+        return
+
+    def build(self) -> None:
+        """Build workflow."""
+        # get active branch
+        self._active_branch = self.versions.active_branch
+
+        self._built_version = []
+        EventHandlers.VERSIONS = BuiltVersions(self._versions_to_build, self.versions.build_directory)
+
+        for tag in self._versions_to_build:
+            log.info(f"Building: {tag}")
+            try:
+                self._build(tag.name)
+                self._built_version.append(tag)
+            except SphinxError:
+                log.error(f"build failed for {tag}")
+                exit(-1)
+            finally:
+                # restore to active branch
+                self.versions.checkout(self._active_branch)
+        return
+
+    pass

--- a/sphinx_versioned/lib.py
+++ b/sphinx_versioned/lib.py
@@ -8,6 +8,15 @@ import tempfile
 import functools
 
 from loguru import logger as log
+from sphinx.config import Config as SphinxConfig
+
+
+class ConfigInject(SphinxConfig):
+    """Inject this extension into `self.extensions`. Append after user's extensions."""
+
+    def __init__(self, *args):
+        super(ConfigInject, self).__init__(*args)
+        self.extensions.append("sphinx_versioned.sphinx_")
 
 
 class HandledError(Exception):

--- a/sphinx_versioned/lib.py
+++ b/sphinx_versioned/lib.py
@@ -8,6 +8,8 @@ import tempfile
 import functools
 
 from loguru import logger as log
+
+from sphinx import application
 from sphinx.config import Config as SphinxConfig
 
 
@@ -17,6 +19,8 @@ class ConfigInject(SphinxConfig):
     def __init__(self, *args):
         super(ConfigInject, self).__init__(*args)
         self.extensions.append("sphinx_versioned.sphinx_")
+
+    pass
 
 
 class HandledError(Exception):
@@ -29,6 +33,8 @@ class HandledError(Exception):
     def show(self, **_):
         """Error messages should be logged before raising this exception."""
         log.critical("Failure.")
+
+    pass
 
 
 class TempDir(object):
@@ -65,3 +71,16 @@ class TempDir(object):
         )
         if os.path.exists(self.name):
             raise IOError(17, "File exists: '{}'".format(self.name))
+
+    pass
+
+
+def mp_sphinx_compatibility() -> bool:
+    """
+    Monkeypatching `sphinx.application.Sphinx.add_stylesheet` -> `sphinx.application.Sphinx.add_stylesheet`
+    to add compatibility for versions using older sphinx
+    """
+    log.info("Monkeypatching older sphinx app.add_stylesheet -> app.add_css_file")
+    application.Sphinx.add_stylesheet = application.Sphinx.add_css_file
+
+    return True

--- a/sphinx_versioned/sphinx_.py
+++ b/sphinx_versioned/sphinx_.py
@@ -3,13 +3,12 @@
 import os
 
 from loguru import logger as log
+from sphinx.util.fileutil import copy_asset_file
 from sphinx.jinja2glue import SphinxFileSystemLoader
 from sphinx.builders.html import StandaloneHTMLBuilder
 
 from sphinx_versioned._version import __version__
-from sphinx.util.fileutil import copy_asset_file
 
-SC_VERSIONING_VERSIONS = list()  # Updated after forking.
 STATIC_DIR = os.path.join(os.path.dirname(__file__), "_static")
 
 


### PR DESCRIPTION
- Segregated building workflow `VersionedDocs` from `__main__.py` to `build.py`
- Moved sphinx-compatibility monkeypatch to `sphinx_versioned/lib.py`