### PR TITLE
Fixed a bug where the versions selector menu shows a scoll-bar in sphinx-rtd-theme

### DIFF
--- a/docs/changes/55.bugfix.rst
+++ b/docs/changes/55.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where the versions selector menu shows a scoll-bar in `sphinx-rtd-theme`.

--- a/sphinx_versioned/_static/_rst_properties.css
+++ b/sphinx_versioned/_static/_rst_properties.css
@@ -5,6 +5,12 @@
     height: auto;
 }
 
+.rst-versions.shift-up {
+    height: auto;
+    max-height: 100%;
+    overflow-y: auto;
+}
+
 .rst-other-versions {
     text-align: left;
 }


### PR DESCRIPTION
Fixes #54 