### PR TITLE
Removed `--branches` in favour of ``--branch`` and ``-b``

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,21 +42,24 @@ How to use
 
     Usage: sphinx-versioned [OPTIONS]
 
+    Create sphinx documentation with a version selector menu.
+
     ╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │ --chdir                                        TEXT  Make this the current working directory before running. [default: None]                              │
-    │ --output                -O                     TEXT  Output directory [default: docs/_build]                                                              │
-    │ --git-root                                     TEXT  Path to directory in the local repo. Default is CWD.                                                 │
-    │ --local-conf                                   TEXT  Path to conf.py for sphinx-versions to read config from. [default: docs/conf.py]                     │
-    │ --reset-intersphinx     -rI                          Reset intersphinx mapping; acts as a patch for issue #17                                             │
-    │ --sphinx-compatibility  -Sc                          Adds compatibility for older sphinx versions by monkey patching certain functions.                   │
-    │ --prebuild                    --no-prebuild          Disables the pre-builds; halves the runtime [default: prebuild]                                      │
-    │ --branches              -b                     TEXT  Build docs for specific branches and tags [default: None]                                            │
-    │ --main-branch           -m                     TEXT  Main branch to which the top-level `index.html` redirects to. Defaults to `main`. [default: None]    │
-    │ --quite                       --no-quite             No output from `sphinx` [default: quite]                                                             │
-    │ --verbose               -v                           Passed directly to sphinx. Specify more than once for more logging in sphinx.                        │
-    │ --log                   -log                   TEXT  Provide logging level. Example --log debug, default=info [default: info]                             │
-    │ --force                                              Force branch selection. Use this option to build detached head/commits. [Default: False]             │
-    │ --help                                               Show this message and exit.                                                                          │
+    │ --chdir                                          TEXT  Make this the current working directory before running. [default: None]                            │
+    │ --output                  -O                     TEXT  Output directory. [default: docs/_build]                                                           │
+    │ --git-root                                       TEXT  Path to directory in the local repo. Default is CWD.                                               │
+    │ --local-conf                                     TEXT  Path to conf.py for sphinx-versions to read config from. [default: docs/conf.py]                   │
+    │ --reset-intersphinx       -rI                          Reset intersphinx mapping; acts as a patch for issue #17                                           │
+    │ --sphinx-compatibility    -Sc                          Adds compatibility for older sphinx versions by monkey patching certain functions.                 │
+    │ --prebuild                      --no-prebuild          Pre-builds the documentations; Use `--no-prebuild` to half the runtime. [default: prebuild]        │
+    │ --branch                  -b                     TEXT  Build documentation for specific branches and tags. [default: None]                                │
+    │ --main-branch             -m                     TEXT  Main branch to which the top-level `index.html` redirects to. Defaults to `main`.                  │
+    │ --floating-badge,--badge                               Turns the version selector menu into a floating badge.                                             │
+    │ --quite                         --no-quite             Silent `sphinx`. Use `--no-quite` to get build output from `sphinx`. [default: quite]              │
+    │ --verbose                 -v                           Passed directly to sphinx. Specify more than once for more logging in sphinx.                      │
+    │ --log                     -log                   TEXT  Provide logging level. Example --log debug, default=info [default: info]                           │
+    │ --force                                                Force branch selection. Use this option to build detached head/commits. [Default: False]           │
+    │ --help                                                 Show this message and exit.                                                                        │
     ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 .. |python-versions| image:: https://img.shields.io/pypi/pyversions/sphinx-versioned-docs.svg?logo=python&logoColor=FBE072

--- a/docs/changes/67.removal.rst
+++ b/docs/changes/67.removal.rst
@@ -1,0 +1,1 @@
+The CLI option ``--branches`` is removed in favour of ``--branch`` and ``-b``.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -55,9 +55,12 @@ These command line options must be specified when executing the ``sphinx-version
 
     Pre-build all versions to make sure ``sphinx-build`` has no issues and pass-on the successful builds to ``sphinx-versioned-docs``. Default is `True`.
 
-.. option:: -b <branch names separated by `,` or `|`>, --branches <branch names separated by `,` or `|`>
+.. option:: -b <branch names>, --branch <branch names>
 
     Build docs and the version selector menu only for certain tags and branches.
+    The branch names can be separated by ``,`` or ``|``.
+
+    Example: ``sphinx-versioned --branch="main, v1.0, v2.0"``
 
 .. option:: -m <branch name>, --main-branch <branch name>
 

--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -48,8 +48,8 @@ def main(
     select_branches: str = typer.Option(
         None,
         "-b",
-        "--branches",
-        help="Build docs for specific branches and tags.",
+        "--branch",
+        help="Build documentation for specific branches and tags.",
     ),
     main_branch: str = typer.Option(
         None,


### PR DESCRIPTION
- [x] Build tests passed
- [x] Codestyle tests passed
- [x] Added test coverage for new features
- [x] Documentation updated to reflect the changes

-------------------------

Deprecations and Removals
-------------------------------
- The CLI option ``--branches`` is removed in favour of ``--branch`` and ``-b``. (`#67 <https://github.com/devanshshukla99/sphinx-versioned-docs/pull/67>`__)
