### PR TITLE
No more pre-building by-default, switching to recursive builds

### DIFF
--- a/sphinx_versioned/__main__.py
+++ b/sphinx_versioned/__main__.py
@@ -43,7 +43,7 @@ def main(
         help="Adds compatibility for older sphinx versions by monkey patching certain functions.",
     ),
     prebuild: bool = typer.Option(
-        True, help="Pre-builds the documentations; Use `--no-prebuild` to half the runtime."
+        False, help="Pre-builds the documentations; Use `--no-prebuild` to half the runtime."
     ),
     branches: str = typer.Option(
         None,

--- a/sphinx_versioned/build.py
+++ b/sphinx_versioned/build.py
@@ -253,7 +253,9 @@ class VersionedDocs:
                 self._built_version.append(tag)
             except SphinxError:
                 log.error(f"build failed for {tag}")
-                exit(-1)
+                log.warning(f"Re-running build without branch/tag: {tag.name}")
+                self._versions_to_build.remove(tag)
+                self.build()
             finally:
                 # restore to active branch
                 self.versions.checkout(self._active_branch)


### PR DESCRIPTION
❌ stalled until branches can be selected via `conf.py`

-----------------

The package, currently, first prebuilds all branches and tags via vanilla sphinx in an isolated location and then builds all the specified branches/tags via the `sphinx-versioned-docs` extension.
This may work for small projects, however, as the number of branches increases along with the project size, a more reasonable approach will be to build all branches with `sphinx-versioned-docs` and if any fails then initiate the building workflow for all branches except the failed ones.

This recursive approach will improve build times.
Branches to be ignored can be specified via `--branch` arg as mentioned in #69 
 
(If any branch build fails then the building workflow is re-initated for all branches except the failed one. Pre-building can still be enabled via `--prebuild` cli arg.)

- [ ] Build tests passed
- [ ] Codestyle tests passed
- [ ] Added test coverage for new features
- [ ] Documentation updated to reflect the changes

-------------------------
